### PR TITLE
Import PropTypes in a reactjs-16 way

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import createFragment from 'react-addons-create-fragment';
 


### PR DESCRIPTION
PropTypes now reside in a separate module, accessing React.PropTypes is error.